### PR TITLE
Modified the sentence test

### DIFF
--- a/src/PigLatinTest.java
+++ b/src/PigLatinTest.java
@@ -11,14 +11,7 @@ public class PigLatinTest {
 
 		//return String.join(" ", words);
 		String translation = PigLatin.translateSentence(sentence);
-		String truth = PigLatin.translateWord("Lorem") + " " +
-				PigLatin.translateWord("ipsum") + " " +
-				PigLatin.translateWord("dolor") + " " +
-				PigLatin.translateWord("sit") + " " +
-				PigLatin.translateWord("amet") + ", " +
-				PigLatin.translateWord("consectetuer") + " " +
-				PigLatin.translateWord("adipiscing") + " " +
-				PigLatin.translateWord("elit") + ".";
+		String truth = "Oremlay ipsumway olorday itsay ametway, onsectetuercay adipiscingway elitway.";
 		assertEquals(translation, truth);
 	}
 


### PR DESCRIPTION
Modified the sentence test. Before the change, the true string were calculated using the same method as in translateSentence. This could potentially cause some false passing tests. With my pull request, the true value is specified explicit.